### PR TITLE
Make annot work with absolute filenames.

### DIFF
--- a/src/main.nw
+++ b/src/main.nw
@@ -84,7 +84,7 @@ let find_file file =
 let with_file file action =
     let file =
       try find_file file
-      with Not_found -> print_string ("Cannot find " ^ file); exit 1 in
+      with Not_found -> file in (* being clever didn't work, try being stupid *)
     let ic = open_in file in
     try 
         let result = action ic in


### PR DESCRIPTION
Annot is very subtle when trying to open the given file, for some reason.
When passed an absolute name that's outside of current working directory,
though, it usually fails, with an irritating error message saying that it
can't find this file although the filename is correct.
This happen all the time in VIM when opening a source file from another
repository.
Couldn't stand this anymore so replaced "output an error message and exit"
with "just use the given filename".