### PR TITLE
Fix for OCaml v4.07.0

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -99,10 +99,10 @@ load.ml:    $(CMO)
 # -- rules
 
 %.ml:       %.nw
-	    $(NOTANGLE) '-L# %L "%F"%N' -R$@ $< > $@
+	    $(NOTANGLE) -R$@ $< > $@
 
 %.mli:      %.nw
-	    $(NOTANGLE) '-L# %L "%F"%N' -R$@ $< > $@
+	    $(NOTANGLE) -R$@ $< > $@
 
 %.sig:	    %.ml
 	    $(OCAMLC) $(OCAMLC_FLAGS) -c -i $< > $@
@@ -131,13 +131,13 @@ load.ml:    $(CMO)
 # -- special rules
 
 scanner.mli: syntax.nw
-	    $(NOTANGLE) '-L# %L "%F"%N' -R$@ $< > $@
+	    $(NOTANGLE) -R$@ $< > $@
 
 scanner.mll: syntax.nw
-	    $(NOTANGLE) '-L# %L "%F"%N' -R$@ $< > $@
+	    $(NOTANGLE) -R$@ $< > $@
 
 parser.mly: syntax.nw
-	    $(NOTANGLE) '-L# %L "%F"%N' -R$@ $< > $@
+	    $(NOTANGLE) -R$@ $< > $@
 
 # -- documentation
 


### PR DESCRIPTION
At some point between 4.06 and 4.07 the OCaml compiler stopped to
parse linenum indications that do not start at column 0.
The nofake untangle tool fails to meet this requirement, therefore
making annot fails to build with 4.07.
As a workaround, I disabled linenum indication generation.

A better fix would be to fix nofake or better yet, to replace it with
portia which I cured yesterday of the very same condition. :)

Alternatively, you could include the generated source files in the git
repository.